### PR TITLE
Replaced fb.me CDN with cdnjs.com

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -13,8 +13,8 @@
     <link rel="canonical" href="https://repo.nmsdb.info">
     <link rel="icon" sizes="196x196" href="/res/icon.png">
     <link rel="stylesheet" href="/styles/repo.css">
-    <script src="https://fb.me/react-15.2.1.min.js" defer></script>
-    <script src="https://fb.me/react-dom-15.2.1.min.js" defer></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.2.1/react.min.js" defer></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.2.1/react-dom.min.js" defer></script>
     <script src="https://npmcdn.com/react-router/umd/ReactRouter.min.js" defer></script>
     <script src="/scripts/repo.js" defer></script>
     <script src="/scripts/redirect.js" async></script>


### PR DESCRIPTION
Using a Facebook CDN like fb.me for essential stuff like React.js can be problematic since many places (work, college, school, privacy-cautious individuals) often block all Facebook domains. This causes the page to be stuck at "waiting for resources..." without any additional info.

I've simply replaced the fb.me with a cdnjs-URL. I assume you should also be able to configure your build process to include it without needing to rely on a CDN (it's also already a (dev-)dependency in package.json), but I'm honestly not overly familiar with webpack and not sure where to include it without possibly breaking other things.
